### PR TITLE
ESP-IDF version check fix, voltage offset removed.

### DIFF
--- a/ESP32AnalogRead.cpp
+++ b/ESP32AnalogRead.cpp
@@ -144,5 +144,5 @@ uint32_t ESP32AnalogRead::readMiliVolts() {
 	uint32_t voltage = 0;
 	// Read ADC and obtain result in mV
 	esp_adc_cal_get_voltage(channel, &characteristics, &voltage);
-	return voltage - 50;
+	return voltage;
 }

--- a/ESP32AnalogRead.cpp
+++ b/ESP32AnalogRead.cpp
@@ -128,18 +128,18 @@ uint32_t ESP32AnalogRead::readMiliVolts() {
 	}
 	// Calculate ADC characteristics i.e. gain and offset factors
 #ifdef ESP_IDF_VERSION
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(3, 1, 0)
 	esp_adc_cal_characterize(unit,
 			ADC_ATTEN_DB_11,
 			ADC_WIDTH_BIT_12,
 			V_REF,
 			&characteristics);
+#else
+	esp_adc_cal_get_characteristics(V_REF, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_12,&characteristics);
 #endif
 #else
 	esp_adc_cal_get_characteristics(V_REF, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_12,&characteristics);
 #endif
-
-
 
 	uint32_t voltage = 0;
 	// Read ADC and obtain result in mV


### PR DESCRIPTION
Hi.
I think library should not introduce any calibration values as long as it gets them from inside the chip already, so I suggest to remove -50mv offset :)
If custom offset needed then it can be added as a separate feature like addOffset() or smth.

Also latest Platform.io environment has ESP-IDF 3.4.4 for Arduino framework and #ifdefs worked incorrectly resulting in wrong result (max uint32_t - 50 actually).
So I have fixed those.