### PR TITLE
Removed unused variable 'voltage'

### DIFF
--- a/ESP32AnalogRead.cpp
+++ b/ESP32AnalogRead.cpp
@@ -646,7 +646,6 @@ uint16_t ESP32AnalogRead::readRaw()
 #endif
 
 	int raw = 0;
-	uint32_t voltage = 0;
 	// Read ADC and obtain result in mV
 	if (unit == ADC_UNIT_1)
 	{


### PR DESCRIPTION
Removed unused variable 'voltage' in readRaw() to avoid a compiler warning (which was treated as an error by arduino-cli used for integration testing)